### PR TITLE
make sure linkedin url can be compare against other object types

### DIFF
--- a/lib/linkedin_url_value.rb
+++ b/lib/linkedin_url_value.rb
@@ -137,4 +137,4 @@ module LinkedinUrlValue
   end
 end
 
-require_relative "linkedin_url_value/railtie" if defined?(Rails) && defined?(Rails::Railtie)
+require_relative "linkedin_url_value/railtie" if defined?(Rails::Railtie)

--- a/lib/linkedin_url_value.rb
+++ b/lib/linkedin_url_value.rb
@@ -72,6 +72,10 @@ module LinkedinUrlValue
     def exceptional_errors(errors, attribute, _options = nil)
       errors.add(attribute, @reason)
     end
+
+    def to_str
+      @raw_value.to_s
+    end
   end
 
   class Regular
@@ -86,12 +90,13 @@ module LinkedinUrlValue
     return val if val.is_a?(Base)
     return AsBlank.new(val) if val.blank?
 
+    val = val.to_str
     valid_format = valid_linkedin_format?(val)
     cleaned_url = clean_url(val)
     return Regular.new(cleaned_url) if valid_format && cleaned_url.include?("https://www.linkedin.com/in/")
 
     Exceptional.new(val)
-  rescue URI::InvalidURIError
+  rescue URI::InvalidURIError, NoMethodError
     Exceptional.new(val)
   end
 

--- a/linkedin_url_value.gemspec
+++ b/linkedin_url_value.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |spec|
   spec.name = "linkedin_url_value"
-  spec.version = "0.2.0"
+  spec.version = "0.2.1"
   spec.authors = ["Grant Petersen-Speelman"]
   spec.email = ["grant@nexl.io"]
 

--- a/spec/linkedin_url_value_spec.rb
+++ b/spec/linkedin_url_value_spec.rb
@@ -107,7 +107,7 @@ RSpec.describe LinkedinUrlValue do
       end
 
       it "can be compared with other objects" do # rubocop:disable RSpec/NoExpectationExample
-        cast(regular_value).eql?(Object.new)
+        cast(cast(regular_value)).eql?(Object.new)
         cast(cast(blank_value)).eql?(Object.new)
         cast(cast(exceptional_value)).eql?(Object.new)
       end

--- a/spec/linkedin_url_value_spec.rb
+++ b/spec/linkedin_url_value_spec.rb
@@ -105,6 +105,12 @@ RSpec.describe LinkedinUrlValue do
         expect(first_cast).not_to eql(second_cast)
         expect([first_cast, second_cast].uniq).to have_attributes(size: 2)
       end
+
+      it "can be compared with other objects" do # rubocop:disable RSpec/NoExpectationExample
+        cast(regular_value).eql?(Object.new)
+        cast(cast(blank_value)).eql?(Object.new)
+        cast(cast(exceptional_value)).eql?(Object.new)
+      end
     end
   end
 


### PR DESCRIPTION
Sometimes linkedin url objects will be compared against other object types, like when used in a hash.
This change makes sure that an error is not raised when being compared against other object types.

fixes https://app.circleci.com/pipelines/github/NEXL-LTS/nexl360/56200/workflows/98a7e632-e732-4413-8f55-83e02159711d/jobs/1018098